### PR TITLE
strtok the resques url before right trimming the /

### DIFF
--- a/router.php
+++ b/router.php
@@ -28,8 +28,8 @@ function route($route, $path_to_include){
     exit();
   }  
   $request_url = filter_var($_SERVER['REQUEST_URI'], FILTER_SANITIZE_URL);
-  $request_url = rtrim($request_url, '/');
   $request_url = strtok($request_url, '?');
+  $request_url = rtrim($request_url, '/');
   $route_parts = explode('/', $route);
   $request_url_parts = explode('/', $request_url);
   array_shift($route_parts);


### PR DESCRIPTION
In the original code :
> $request_url = rtrim($request_url, '/');
> $request_url = strtok($request_url, '?');

The trim was done before the split. But this leads to issues when dealing with paths like this one :
``https://example.com/pricing/?type=0``
Indeed, the first line will trim an unexisting ``/`` at the end of the request url.
And the second will remove the GET query parameters.
Resulting in this :
``https://example.com/pricing/``
This left a remaining right ``/`` that will create an element at the end of the exploded array.

Then, the condition:
> if( count($route_parts) != count($request_url_parts) ){ return; }
will be evaluated as true and the router will return while it should not.

The request_url should firstly be split to remove everything after the first ``?``:
>  $request_url = strtok($request_url, '?');
And only then, the $request_url should be right trimmed to remove the last ``/``:
>  $request_url = rtrim($request_url, '/');

Then, I just inverted these two lines.